### PR TITLE
Limit event triggering to current subscribers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Patches and Suggestions
 
 - Eric Smith
 - Evan Klitzke
+- Thomas Hanssen Nornes

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Docs: fix (Evan Klitzke)
+- Limit events to only trigger current subscribers
 
 Version 0.2.1
 -------------

--- a/events/events.py
+++ b/events/events.py
@@ -73,7 +73,7 @@ class _EventSlot:
         return "event '%s'" % self.__name__
 
     def __call__(self, *a, **kw):
-        for f in self.targets:
+        for f in tuple(self.targets):
             f(*a, **kw)
 
     def __iadd__(self, f):


### PR DESCRIPTION
If you needed to register more subscribers to  an event inside the
execution context of that same event you would run into recursion
problems. The solution is to create a copy of the current
subscribers before executing them.